### PR TITLE
Refactor controllers to use ApiResponse wrapper

### DIFF
--- a/src/main/java/com/ni/la/oa/elearn/api/CourseController.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/CourseController.java
@@ -1,17 +1,21 @@
 package com.ni.la.oa.elearn.api;
 
+import com.ni.la.oa.elearn.api.dto.ApiResponse;
 import com.ni.la.oa.elearn.api.dto.cource.CourseRequest;
 import com.ni.la.oa.elearn.api.dto.cource.CourseResponse;
 import com.ni.la.oa.elearn.api.dto.cource.LessonRequest;
 import com.ni.la.oa.elearn.api.dto.cource.LessonResponse;
+import com.ni.la.oa.elearn.api.dto.error.ApiError;
 import com.ni.la.oa.elearn.domain.Course;
 import com.ni.la.oa.elearn.domain.Lesson;
 import com.ni.la.oa.elearn.repo.CourseRepository;
 import com.ni.la.oa.elearn.repo.LessonRepository;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -30,54 +34,66 @@ public class CourseController {
     // ---- TEACHER: create course
     @PreAuthorize("hasRole('TEACHER')")
     @PostMapping
-    public ResponseEntity<CourseResponse> create(@Valid @RequestBody CourseRequest req) {
+    public ResponseEntity<ApiResponse<CourseResponse>> create(@Valid @RequestBody CourseRequest req) {
         if (courses.existsByTitle(req.title())) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(
+                    ApiResponse.error(new ApiError("TITLE_EXISTS", "Course title already exists"))
+            );
         }
         Course c = new Course();
         c.setTitle(req.title());
         c.setDescription(req.description());
         courses.save(c);
-        return ResponseEntity.ok(new CourseResponse(c.getId(), c.getTitle(), c.getDescription()));
+        return ResponseEntity.ok(ApiResponse.success(
+                new CourseResponse(c.getId(), c.getTitle(), c.getDescription()))
+        );
     }
 
     // ---- STUDENT: view all courses
     @PreAuthorize("hasAnyRole('STUDENT','TEACHER')")
     @GetMapping
-    public List<CourseResponse> all() {
-        return courses.findAll().stream()
+    public ResponseEntity<ApiResponse<List<CourseResponse>>> all() {
+        List<CourseResponse> list = courses.findAll().stream()
             .map(c -> new CourseResponse(c.getId(), c.getTitle(), c.getDescription()))
             .toList();
+        return ResponseEntity.ok(ApiResponse.success(list));
     }
 
     // ---- TEACHER: add lesson to a course
     @PreAuthorize("hasRole('TEACHER')")
     @PostMapping("/{courseId}/lessons")
-    public ResponseEntity<LessonResponse> addLesson(@PathVariable Long courseId,
+    public ResponseEntity<ApiResponse<LessonResponse>> addLesson(@PathVariable Long courseId,
                                                     @Valid @RequestBody LessonRequest req) {
-        Course c = courses.findById(courseId).orElseThrow();
+        Course c = courses.findById(courseId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Course not found"));
         Lesson l = new Lesson();
         l.setTitle(req.title());
         l.setContent(req.content());
         l.setCourse(c);
         lessons.save(l);
-        return ResponseEntity.ok(new LessonResponse(l.getId(), l.getTitle(), l.getContent(), c.getId()));
+        return ResponseEntity.ok(ApiResponse.success(
+                new LessonResponse(l.getId(), l.getTitle(), l.getContent(), c.getId()))
+        );
     }
 
     @PreAuthorize("hasAnyRole('STUDENT','TEACHER')")
     @GetMapping("/{id}")
-    public ResponseEntity<CourseResponse> byId(@PathVariable Long id) {
-        return courses.findById(id)
-                .map(c -> ResponseEntity.ok(new CourseResponse(c.getId(), c.getTitle(), c.getDescription())))
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    public ResponseEntity<ApiResponse<CourseResponse>> byId(@PathVariable Long id) {
+        Course c = courses.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Course not found"));
+        return ResponseEntity.ok(ApiResponse.success(
+                new CourseResponse(c.getId(), c.getTitle(), c.getDescription()))
+        );
     }
+
     @PreAuthorize("hasAnyRole('STUDENT','TEACHER')")
     @GetMapping("/{courseId}/lessons")
-    public ResponseEntity<List<LessonResponse>> getLessons(@PathVariable Long courseId) {
-        if (!courses.existsById(courseId)) return ResponseEntity.notFound().build();
-        var list = lessons.findByCourseId(courseId).stream()
+    public ResponseEntity<ApiResponse<List<LessonResponse>>> getLessons(@PathVariable Long courseId) {
+        Course c = courses.findById(courseId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Course not found"));
+        List<LessonResponse> list = lessons.findByCourseId(c.getId()).stream()
                 .map(l -> new LessonResponse(l.getId(), l.getTitle(), l.getContent(), courseId))
                 .toList();
-        return ResponseEntity.ok(list);
+        return ResponseEntity.ok(ApiResponse.success(list));
     }
 }

--- a/src/main/java/com/ni/la/oa/elearn/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ public class GlobalExceptionHandler {
 
     // Handle explicit ResponseStatusException
     @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<ApiResponse<?>> handleResponseStatus(ResponseStatusException ex) {
+    public ResponseEntity<ApiResponse<ApiError>> handleResponseStatus(ResponseStatusException ex) {
         ApiError error = new ApiError(
                 ex.getStatusCode().toString(),
                 ex.getReason() != null ? ex.getReason() : "Unexpected error"
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
 
     // Handle validation errors (@Valid on DTOs)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ApiResponse<ApiError>> handleValidation(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         ApiError error = new ApiError("VALIDATION_ERROR", message);
         return ResponseEntity.badRequest().body(ApiResponse.error(error));
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
 
     // Fallback handler for unexpected exceptions
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<?>> handleGeneric(Exception ex) {
+    public ResponseEntity<ApiResponse<ApiError>> handleGeneric(Exception ex) {
         ApiError error = new ApiError("INTERNAL_ERROR", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(error));
     }

--- a/src/main/java/com/ni/la/oa/elearn/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ public class GlobalExceptionHandler {
 
     // Handle explicit ResponseStatusException
     @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<ApiResponse<Void>> handleResponseStatus(ResponseStatusException ex) {
+    public ResponseEntity<ApiResponse<?>> handleResponseStatus(ResponseStatusException ex) {
         ApiError error = new ApiError(
                 ex.getStatusCode().toString(),
                 ex.getReason() != null ? ex.getReason() : "Unexpected error"
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
 
     // Handle validation errors (@Valid on DTOs)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         ApiError error = new ApiError("VALIDATION_ERROR", message);
         return ResponseEntity.badRequest().body(ApiResponse.error(error));
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
 
     // Fallback handler for unexpected exceptions
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleGeneric(Exception ex) {
+    public ResponseEntity<ApiResponse<?>> handleGeneric(Exception ex) {
         ApiError error = new ApiError("INTERNAL_ERROR", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(error));
     }

--- a/src/main/java/com/ni/la/oa/elearn/api/TeacherDashboardController.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/TeacherDashboardController.java
@@ -1,5 +1,6 @@
 package com.ni.la.oa.elearn.api;
 
+import com.ni.la.oa.elearn.api.dto.ApiResponse;
 import com.ni.la.oa.elearn.api.dto.cource.QuestionStatDto;
 import com.ni.la.oa.elearn.api.dto.cource.QuizStatsResponse;
 import com.ni.la.oa.elearn.api.dto.cource.StudentScoreDto;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -32,12 +34,9 @@ public class TeacherDashboardController {
     @PreAuthorize("hasRole('TEACHER')")
     @GetMapping("/quizzes/{quizId}/stats")
     @Transactional(readOnly = true)
-    public ResponseEntity<QuizStatsResponse> quizStats(@PathVariable Long quizId) {
-        var quizOpt = quizzes.findById(quizId);
-        if (quizOpt.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
-        Quiz quiz = quizOpt.get();
+    public ResponseEntity<ApiResponse<QuizStatsResponse>> quizStats(@PathVariable Long quizId) {
+        Quiz quiz = quizzes.findById(quizId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Quiz not found"));
 
         long totalSubmissions = submissions.countByQuestion_Quiz_Id(quizId);
         long studentsAttempted = submissions.countDistinctStudentsByQuizId(quizId);
@@ -78,6 +77,6 @@ public class TeacherDashboardController {
                 perQuestion,
                 leaderboard
         );
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok(ApiResponse.success(body));
     }
 }

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Generic wrapper for all API responses.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(name = "ApiResponse", description = "Generic wrapper for all API responses")
 public class ApiResponse<T> {
     @Schema(description = "Payload returned on success")
     private T data;

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
@@ -7,18 +7,36 @@ import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * Generic wrapper for all API responses.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL) // hide null fields in JSON
-public record ApiResponse<T>(
-        @Schema(description = "Payload returned on success") T data,
-        @Schema(description = "Error details when the request is not successful") ApiError error
-) {
-    // Success factory
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(name = "ApiResponse", description = "Generic wrapper for all API responses")
+public class ApiResponse<T> {
+    @Schema(description = "Payload returned on success")
+    private T data;
+
+    @Schema(description = "Error details when the request is not successful")
+    private ApiError error;
+
+    public ApiResponse() {
+    }
+
+    public ApiResponse(T data, ApiError error) {
+        this.data = data;
+        this.error = error;
+    }
+
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(data, null);
     }
 
-    // Error factory
     public static <T> ApiResponse<T> error(ApiError error) {
         return new ApiResponse<>(null, error);
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public ApiError getError() {
+        return error;
     }
 }

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ni.la.oa.elearn.api.dto.error.ApiError;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "Generic wrapper for all API responses")
+/**
+ * Generic wrapper for all API responses.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL) // hide null fields in JSON
 public record ApiResponse<T>(
         @Schema(description = "Payload returned on success") T data,

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
@@ -2,11 +2,13 @@ package com.ni.la.oa.elearn.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ni.la.oa.elearn.api.dto.error.ApiError;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "Generic wrapper for all API responses")
 @JsonInclude(JsonInclude.Include.NON_NULL) // hide null fields in JSON
 public record ApiResponse<T>(
-        T data,
-        ApiError error
+        @Schema(description = "Payload returned on success") T data,
+        @Schema(description = "Error details when the request is not successful") ApiError error
 ) {
     // Success factory
     public static <T> ApiResponse<T> success(T data) {

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/error/ApiError.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/error/ApiError.java
@@ -1,9 +1,12 @@
 package com.ni.la.oa.elearn.api.dto.error;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Details about an error returned by the API")
 public record ApiError(
-        String code,
-        String message,
-        String details
+        @Schema(description = "Machine readable error code") String code,
+        @Schema(description = "Human readable error message") String message,
+        @Schema(description = "Additional details that may help debugging", nullable = true) String details
 ) {
     public ApiError(String code, String message) {
         this(code, message, null);

--- a/src/main/java/com/ni/la/oa/elearn/repo/SubmissionRepository.java
+++ b/src/main/java/com/ni/la/oa/elearn/repo/SubmissionRepository.java
@@ -18,10 +18,10 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
         from Submission s
         where s.question.quiz.id = :quizId
     """)
-    long countDistinctStudentsByQuizId(Long quizId);
+    long countDistinctStudentsByQuizId(@Param("quizId") Long quizId);
 
     @Query("""
-    select new com.ni.la.oa.elearn.api.dto.QuestionStatDto(
+    select new com.ni.la.oa.elearn.api.dto.cource.QuestionStatDto(
         s.question.id,
         count(s),
         sum(case when s.correct = true then 1 else 0 end),
@@ -36,7 +36,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
 
 
     @Query("""
-    select new com.ni.la.oa.elearn.api.dto.StudentScoreDto(
+    select new com.ni.la.oa.elearn.api.dto.cource.StudentScoreDto(
         s.student.id,
         s.student.email,
         sum(case when s.correct = true then 1 else 0 end),


### PR DESCRIPTION
## Summary
- wrap AuthController endpoints with `ResponseEntity<ApiResponse<T>>` and include structured error responses
- refactor CourseController, LessonController, QuizController, and TeacherDashboardController to return `ApiResponse` wrappers and use `ResponseStatusException` for missing resources

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1601e9fc4832586c7bdc314365a27