### PR TITLE
fix: ensure swagger handles ApiResponse

### DIFF
--- a/src/main/java/com/ni/la/oa/elearn/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/GlobalExceptionHandler.java
@@ -14,7 +14,7 @@ public class GlobalExceptionHandler {
 
     // Handle explicit ResponseStatusException
     @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<ApiResponse<ApiError>> handleResponseStatus(ResponseStatusException ex) {
+    public ResponseEntity handleResponseStatus(ResponseStatusException ex) {
         ApiError error = new ApiError(
                 ex.getStatusCode().toString(),
                 ex.getReason() != null ? ex.getReason() : "Unexpected error"
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
 
     // Handle validation errors (@Valid on DTOs)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<ApiError>> handleValidation(MethodArgumentNotValidException ex) {
+    public ResponseEntity handleValidation(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         ApiError error = new ApiError("VALIDATION_ERROR", message);
         return ResponseEntity.badRequest().body(ApiResponse.error(error));
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
 
     // Fallback handler for unexpected exceptions
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<ApiError>> handleGeneric(Exception ex) {
+    public ResponseEntity handleGeneric(Exception ex) {
         ApiError error = new ApiError("INTERNAL_ERROR", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(error));
     }

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Generic wrapper for all API responses.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(name = "ApiResponse", description = "Generic wrapper for all API responses")
 public class ApiResponse<T> {
     @Schema(description = "Payload returned on success")
     private T data;
@@ -35,7 +36,15 @@ public class ApiResponse<T> {
         return data;
     }
 
+    public void setData(T data) {
+        this.data = data;
+    }
+
     public ApiError getError() {
         return error;
+    }
+
+    public void setError(ApiError error) {
+        this.error = error;
     }
 }

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
@@ -28,7 +28,7 @@ public class ApiResponse<T> {
         return new ApiResponse<>(data, null);
     }
 
-    public static <T> ApiResponse<T> error(ApiError error) {
+    public static ApiResponse<Void> error(ApiError error) {
         return new ApiResponse<>(null, error);
     }
 

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
@@ -28,7 +28,7 @@ public class ApiResponse<T> {
         return new ApiResponse<>(data, null);
     }
 
-    public static ApiResponse<Void> error(ApiError error) {
+    public static <T> ApiResponse<T> error(ApiError error) {
         return new ApiResponse<>(null, error);
     }
 

--- a/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
+++ b/src/main/java/com/ni/la/oa/elearn/api/dto/ApiResponse.java
@@ -8,43 +8,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Generic wrapper for all API responses.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(name = "ApiResponse", description = "Generic wrapper for all API responses")
-public class ApiResponse<T> {
-    @Schema(description = "Payload returned on success")
-    private T data;
-
-    @Schema(description = "Error details when the request is not successful")
-    private ApiError error;
-
-    public ApiResponse() {
-    }
-
-    public ApiResponse(T data, ApiError error) {
-        this.data = data;
-        this.error = error;
-    }
-
+@Schema(description = "Generic wrapper for API responses")
+public record ApiResponse<T>(
+        @Schema(description = "Payload returned on success") T data,
+        @Schema(description = "Error details when the request is not successful") ApiError error
+) {
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(data, null);
     }
 
     public static <T> ApiResponse<T> error(ApiError error) {
         return new ApiResponse<>(null, error);
-    }
-
-    public T getData() {
-        return data;
-    }
-
-    public void setData(T data) {
-        this.data = data;
-    }
-
-    public ApiError getError() {
-        return error;
-    }
-
-    public void setError(ApiError error) {
-        this.error = error;
     }
 }

--- a/src/main/java/com/ni/la/oa/elearn/config/OpenApiConfig.java
+++ b/src/main/java/com/ni/la/oa/elearn/config/OpenApiConfig.java
@@ -1,20 +1,13 @@
 package com.ni.la.oa.elearn.config;
 
-import com.ni.la.oa.elearn.api.dto.ApiResponse;
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import org.springdoc.core.utils.SpringDocUtils;
-
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
-
-    static {
-        SpringDocUtils.getConfig().addResponseWrapperToIgnore(ApiResponse.class);
-    }
 
     @Bean
     public OpenAPI api() {

--- a/src/main/java/com/ni/la/oa/elearn/config/OpenApiConfig.java
+++ b/src/main/java/com/ni/la/oa/elearn/config/OpenApiConfig.java
@@ -1,14 +1,20 @@
 package com.ni.la.oa.elearn.config;
 
+import com.ni.la.oa.elearn.api.dto.ApiResponse;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.utils.SpringDocUtils;
 
 @Configuration
 public class OpenApiConfig {
+
+    static {
+        SpringDocUtils.getConfig().addResponseWrapperToIgnore(ApiResponse.class);
+    }
 
     @Bean
     public OpenAPI api() {


### PR DESCRIPTION
## Summary
- annotate and expose setters on ApiResponse to satisfy swagger
- tell OpenAPI to ignore ApiResponse wrapper so swagger can resolve nested types

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b176f326308325aaadb582648afcb9