### PR TITLE
refactor: configure SpringDoc wrapper via PostConstruct

### DIFF
--- a/src/main/java/com/ni/la/oa/elearn/config/OpenApiConfig.java
+++ b/src/main/java/com/ni/la/oa/elearn/config/OpenApiConfig.java
@@ -2,13 +2,22 @@ package com.ni.la.oa.elearn.config;
 
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import jakarta.annotation.PostConstruct;
+import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.ni.la.oa.elearn.api.dto.ApiResponse;
 
 @Configuration
 public class OpenApiConfig {
+
+    @PostConstruct
+    public void configure() {
+        SpringDocUtils.getConfig().addResponseWrapperToIgnore(ApiResponse.class);
+    }
 
     @Bean
     public OpenAPI api() {


### PR DESCRIPTION
## Summary
- Ignore ApiResponse wrapper for OpenAPI via `@PostConstruct`
- Retain API security scheme configuration

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b18979081483258e62029a188f2ef4